### PR TITLE
Update serviceURL to redirect from Inbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
   "author": "Stefan Malzner <stefan@adlk.io>",
   "license": "MIT",
   "config": {
-    "serviceURL": "https://mail.google.com"
+    "serviceURL": "https://mail.google.com/mail/?ibxr=0"
   }
 }


### PR DESCRIPTION
Add GET variable ibxr=0 to URL so that folks with Google Inbox enabled on their Google Accounts get redirected to Gmail in the Gmail service recipe, not Inbox. I copied URL directly from the redirector button in Google Inbox.

Tested and working in Windows, Franz 5.0.0-beta.15 including badges, notifications

Why? Because Inbox's auto-filter things aren't exportable, nor visible, so I like making my filters in Gmail, and viewing the effects in Inbox.