### PR TITLE
Gmail unread count for sorted inbox

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -18,8 +18,13 @@ module.exports = (Franz) => {
       }
 
       // 1st best
-      if (document.getElementsByClassName('J-Ke n0')[0].getAttribute('title') != null) {
-        count = parseInt(document.getElementsByClassName('J-Ke n0')[0].getAttribute('title').replace(/[^0-9.]/g, ''), 10);
+      let title = document.getElementsByClassName('J-Ke n0')[0].getAttribute('title');
+      if (title != null) {
+        if (title.indexOf(':') >= 0){
+          count = parseInt(document.getElementsByClassName('J-Ke n0')[0].getAttribute('title').match(/([0-9]+)\)/)[1], 10);
+        } else {
+          count = parseInt(document.getElementsByClassName('J-Ke n0')[0].getAttribute('title').replace(/[^0-9.]/g, ''), 10);
+        }
       }
     }
 


### PR DESCRIPTION
For a sorted Gmail inbox the title is like:

`Posteingang (1 : 2)`
Where 1 is the number of unread "important" mails and 2 is the number of unread mails in total (including the one unread important mail).
With the current extraction logic the unread count is set to `12`.

This change pays attention to this sorted inbox and properly extracts the second number as unread count.
