### PR TITLE
Fix Gmail Badge Count

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "id": "gmail",
   "name": "Gmail",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Gmail",
   "main": "index.js",
   "author": "Stefan Malzner <stefan@adlk.io>",

--- a/webview.js
+++ b/webview.js
@@ -2,11 +2,8 @@ module.exports = (Franz) => {
   const getMessages = function getMessages() {
     let count = 0;
 
-    if (document.getElementsByClassName('J-Ke n0').length > 0) {
-      if (document.getElementsByClassName('J-Ke n0')[0].getAttribute('aria-label') != null) {
-        count = parseInt(document.getElementsByClassName('J-Ke n0')[0].getAttribute('aria-label').replace(/[^0-9.]/g, ''), 10);
-      }
-    }
+    // this just gives a count of unread emails in primary tab(which is what we are interested in) and not other tabs 
+    count = parseInt(document.getElementsByTagName("title")[0].innerHTML.replace(/[^0-9.]/g, ''), 10);
 
     // Just incase we don't end up with a number, set it back to zero (parseInt can return NaN)
     count = parseInt(count, 10);


### PR DESCRIPTION
@adlk Currently, Gmail badge count gives a count of unread emails from all the tabs.

However, it is better to show only the count of Unread mails in the Primary tab which is what a user is interested in.