### PR TITLE
Fixing "This document requires 'TrustedHTML' assignment." error that breaks badge count display

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -1,5 +1,11 @@
 import path from 'path';
 
+if (window.trustedTypes && window.trustedTypes.createPolicy) {
+  window.trustedTypes.createPolicy('default', {
+    createHTML: (string, sink) => string
+  });
+}
+
 module.exports = (Franz) => {
   const getMessages = function getMessages() {
     let count = 0;


### PR DESCRIPTION
There must have been a change in the google code that results in the "This document requires 'TrustedHTML' assignment." and prevents the badge counts from being displayed correctly. This change should fix it.